### PR TITLE
install fish completions in fish/vendor_completions.d

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -137,13 +137,13 @@
             postInstall = ''
               export WINEPREFIX="$(mktemp -d)"
 
-              mkdir -p $out/bin/share/{completions,man}
+              mkdir -p $out/bin/share/{completions,man,fish/vendor_completions.d}
 
               cd $out/bin
               ${runner} man ./share/man
               ${runner} completion bash > ./share/completions/neverest.bash
               ${runner} completion elvish > ./share/completions/neverest.elvish
-              ${runner} completion fish > ./share/completions/neverest.fish
+              ${runner} completion fish > ./share/fish/vendor_completions.d/neverest.fish
               ${runner} completion powershell > ./share/completions/neverest.powershell
               ${runner} completion zsh > ./share/completions/neverest.zsh
               tar -czf neverest.tgz neverest* share


### PR DESCRIPTION
Hi,

This enable completions with fish, as fish looks into the `fish/vendor_completions.d` directory

ref. https://github.com/fish-shell/fish-shell/blob/master/doc_src/completions.rst#where-to-put-completions