### PR TITLE
Allow using `override` to add features

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -5,16 +5,11 @@
 pimalaya.mkDefault ({
   src = ./.;
   version = "1.0.0";
-  mkPackage = ({ lib, pkgs, rustPlatform, defaultFeatures, features }: import ./package.nix {
+  mkPackage = ({ lib, pkgs, rustPlatform, defaultFeatures, features }: pkgs.callPackage ./package.nix {
     inherit lib rustPlatform;
-    fetchFromGitHub = pkgs.fetchFromGitHub;
-    stdenv = pkgs.stdenv;
     apple-sdk = if pkgs.hostPlatform.isx86_64 then pkgs.apple-sdk_13 else pkgs.apple-sdk_14;
-    installShellFiles = pkgs.installShellFiles;
     installShellCompletions = false;
     installManPages = false;
-    notmuch = pkgs.notmuch;
-    pkg-config = pkgs.pkg-config;
     buildNoDefaultFeatures = !defaultFeatures;
     buildFeatures = lib.splitString "," features;
   });


### PR DESCRIPTION
This way you can do
```nix
neverest.override {
  buildFeatures = [ "notmuch" "oauth2" ];
}
```

Also this uses any unspecified arguments as if they were given from `pkgs`, so no need to explicitly specify.

See also pimalaya/mirador#5 pimalaya/himalaya#511