### PR TITLE
fix(client): add fallback for imap default ports

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -57,7 +57,11 @@ pub fn open(config: SideConfig) -> Result<EmailClientStd> {
                 .sasl
                 .and_then(|cfg| {
                     let host = server.host_str()?;
-                    let port = server.port_or_known_default()?;
+                    let port = server.port().or_else(|| match server.scheme() {
+                        "imaps" => Some(993),
+                        "imap" => Some(143),
+                        _ => None,
+                    })?;
                     Some(cfg.try_into_sasl(host, port))
                 })
                 .transpose()?;


### PR DESCRIPTION
The 'port_or_known_default()' method doesn't recognize non-standard URL schemes like 'imap' and 'imaps', causing it to return 'None' for URLs without an explicit port. This breaks connections to IMAP servers using scheme-based URLs.

Explicitly map the IMAP default ports (993 for imaps, 143 for imap) as fallback when no port is specified in the URL.