### PR TITLE
fix: repoint deleted domain patch to parent-repo revision

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -521,7 +521,7 @@ dependencies = [
 [[package]]
 name = "domain"
 version = "0.12.0"
-source = "git+https://github.com/soywod/domain?branch=new-srv#2a72dc6f55212d8b72b046992bc229bfdac48887"
+source = "git+https://github.com/NLnetLabs/domain?rev=2a72dc6f55212d8b72b046992bc229bfdac48887#2a72dc6f55212d8b72b046992bc229bfdac48887"
 dependencies = [
  "bumpalo",
  "bytes",
@@ -534,7 +534,7 @@ dependencies = [
 [[package]]
 name = "domain-macros"
 version = "0.12.0"
-source = "git+https://github.com/soywod/domain?branch=new-srv#2a72dc6f55212d8b72b046992bc229bfdac48887"
+source = "git+https://github.com/NLnetLabs/domain?rev=2a72dc6f55212d8b72b046992bc229bfdac48887#2a72dc6f55212d8b72b046992bc229bfdac48887"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1334,6 +1334,7 @@ dependencies = [
  "serde",
  "serde_json",
  "shellexpand",
+ "signal-hook",
  "tempfile",
  "toml",
  "url",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -78,7 +78,9 @@ tempfile = "3"
 # pimconf.path = "../pimconf"
 
 [patch.crates-io]
-domain = { git = "https://github.com/soywod/domain", branch = "new-srv" }
+# soywod/domain#new-srv is deleted; the commit lives on in the parent repo's
+# network and is fetchable by SHA. "Bring SRV record to new API", 0.12.0.
+domain = { git = "https://github.com/NLnetLabs/domain", rev = "2a72dc6f55212d8b72b046992bc229bfdac48887" }
 imap-codec.git = "https://github.com/soywod/imap-codec"
 io-email.git = "https://github.com/pimalaya/io-email"
 io-http.git = "https://github.com/pimalaya/io-http"


### PR DESCRIPTION
The `[patch.crates-io] domain` entry points at `soywod/domain#new-srv`, which no longer resolves — the fork was removed, and both anonymous and authenticated fetches return 404. As a result the tree cannot be built from a clean checkout by anyone without access to that fork (`cargo`/`nix` fail at git dependency resolution on `soywod/domain`).

The patched commit — "Bring SRV record to new API" (`2a72dc6f55212d8b72b046992bc229bfdac48887`, domain 0.12.0) — is retained in the parent repository's object network and is fetchable by SHA, so this repoints the patch at `NLnetLabs/domain` at that same commit.

No functional change: the exact same `domain` revision is used; only the fetch source changes from the deleted fork to the parent that still carries the object. Verified: `cargo build --features imap` resolves and compiles the full tree (pimconf SRV discovery included) with this change.
